### PR TITLE
Pbi 26 logging

### DIFF
--- a/projects/dvl-fw/src/lib/plugins/activity-log/log-raw-data.ts
+++ b/projects/dvl-fw/src/lib/plugins/activity-log/log-raw-data.ts
@@ -28,7 +28,7 @@ export class ActivityLogRawData implements RawData {
         {key: 'actionName', type: 'string'},
         {key: 'date', type: 'string'},
         {key: 'payload', type: 'string' },
-        {key: 'time', type: 'string'}
+        {key: 'time', type: 'int'}
       ]).actions([{
           name: 'add_new_log',
           args: ['activitylog:map'],

--- a/projects/dvl-fw/src/lib/plugins/activity-log/log-raw-data.ts
+++ b/projects/dvl-fw/src/lib/plugins/activity-log/log-raw-data.ts
@@ -27,7 +27,8 @@ export class ActivityLogRawData implements RawData {
         {key: 'logid', type: 'int', props: ['pk', 'ai']}, // pk == primary key, ai == auto incriment
         {key: 'actionName', type: 'string'},
         {key: 'date', type: 'string'},
-        {key: 'payload', type: 'string' }
+        {key: 'payload', type: 'string' },
+        {key: 'time', type: 'string'}
       ]).actions([{
           name: 'add_new_log',
           args: ['activitylog:map'],
@@ -51,6 +52,7 @@ export class ActivityLogRawData implements RawData {
       id: null,
       actionName: get(msg, 'logData.data.type'),
       date : new Date().toLocaleString(),
+      time: new Date().getTime(),
       payload: JSON.stringify(omit(msg.logData.data.payload, ['project']))
       }
     });

--- a/projects/make-a-vis/src/lib/legend-view/main/main.component.ts
+++ b/projects/make-a-vis/src/lib/legend-view/main/main.component.ts
@@ -28,11 +28,11 @@ export class MainComponent {
 
   constructor(private store: Store<ApplicationState>, private updateService: UpdateVisService) {
     store.pipe(select(getUiFeature)).subscribe(({ activeVisualization, project }) => {
-      const changed = activeVisualization !== this.lastActiveVisualization || project !== this.lastProject;
-      this.lastActiveVisualization = activeVisualization;
+      const changed = activeVisualization.visualizationId !== this.lastActiveVisualization || project !== this.lastProject;
+      this.lastActiveVisualization = activeVisualization.visualizationId;
       this.lastProject = project;
       if (changed) {
-        this.setState(project, activeVisualization);
+        this.setState(project, activeVisualization.visualizationId);
       }
     });
   }

--- a/projects/make-a-vis/src/lib/shared/logging/log.ts
+++ b/projects/make-a-vis/src/lib/shared/logging/log.ts
@@ -1,11 +1,13 @@
 import { Logger, MessageType, LogData, ErrorType, TypescriptLoggerFactory, LogLevel } from '@ngx-dino/core';
 import { Actions, Effect , ofType } from '@ngrx/effects';
-import { SidenavActionTypes, LoadProjectCompleted } from '../../toolbar/shared/store';
-import { catchError, map , exhaustMap, tap } from 'rxjs/operators';
+import { SidenavActionTypes } from '../../toolbar/shared/store';
+import { tap } from 'rxjs/operators';
 import { Action } from '@ngrx/store';
-import { pick, values } from 'lodash';
-import { Observable, of } from 'rxjs';
+import { pick, values, concat, omit } from 'lodash';
+import { Observable } from 'rxjs';
 import { Injectable } from '@angular/core';
+
+import { DataViewActionTypes } from '../../data-view/shared/store';
 
 @Injectable()
 export class LogActions {
@@ -14,29 +16,11 @@ export class LogActions {
   messageType: MessageType;
   logData: LogData;
   errorType: ErrorType;
-  startingActions: any = values(pick(SidenavActionTypes, [
-    'SaveProjectStarted',
-    'SaveProjectCompleted',
-
-    'LoadProjectStarted',
-    'LoadProjectCompleted',
-
-    'ExportSnapshotStarted',
-    'ExportSnapshotCompleted',
-
-    'LoadShareUrlStarted',
-
-    'CreateShareUrlCompleted',
-    'CopyToClipboardSuccess',
-    'LoadShareUrlCompletedPayload',
-
-    'SetRecordStream',
-    'AddNewVisualization',
-    'RemoveVisualization',
-    'SetActiveVisualization'
+  sidenavActions: string[] = values(omit(SidenavActionTypes, [
+    'SaveProjectFileCreated'
   ]));
 
-
+  startingActions = concat(this.sidenavActions, Object.values(DataViewActionTypes));
   errorActions: any = values(pick(SidenavActionTypes, [
     'LoadProjectError',
     'ExportSnapshotError',

--- a/projects/make-a-vis/src/lib/shared/logging/logging-control.service.ts
+++ b/projects/make-a-vis/src/lib/shared/logging/logging-control.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@angular/core';
 import { ApplicationState } from '../../shared/store';
 import * as fromUi from '../../toolbar/shared/store';
 import { StoreLogger } from './store-logger';
-import { Store, select } from '@ngrx/store';
+import { Store } from '@ngrx/store';
 
 import { ToggleLogging } from '../../toolbar/shared/store';
 import { LoggerType } from 'typescript-logging';

--- a/projects/make-a-vis/src/lib/shared/services/export/export.service.ts
+++ b/projects/make-a-vis/src/lib/shared/services/export/export.service.ts
@@ -33,11 +33,11 @@ export class ExportService {
     this.store.dispatch(new ExportSnapshotStarted(true));
     this.exportToPngService.getSnapShot(
       this.getVisualizationElement(),
-      'visualisation.png'
+      'visualization.png'
     );
     this.store.dispatch(new ExportSnapshotCompleted({
       exportingSnapshot: false,
-      fileName: 'visualisation.png',
+      fileName: 'visualization.png',
       fileExtension: 'png'
     }));
   }
@@ -46,10 +46,10 @@ export class ExportService {
     this.store.dispatch(new ExportSnapshotStarted(true));
     this.exportToSvgService.getSnapShot(
       this.getVisualizationElement(),
-      'visualisation.svg');
+      'visualization.svg');
       this.store.dispatch(new ExportSnapshotCompleted({
         exportingSnapshot: false,
-        fileName: 'visualisation.svg',
+        fileName: 'visualization.svg',
         fileExtension: 'svg'
       }));
   }
@@ -60,14 +60,14 @@ export class ExportService {
     this.pdfOptions.preserveAspectRatio = 'xMinYMin';
     this.exportToPdfService.getSnapShot(
       this.getVisualizationElement(),
-      'visualisation.pdf',
+      'visualization.pdf',
       this.pdfOptions,
       0,
       0
     );
     this.store.dispatch(new ExportSnapshotCompleted({
       exportingSnapshot: false,
-      fileName: 'visualisation.pdf',
+      fileName: 'visualization.pdf',
       fileExtension: 'pdf'
     }));
   }

--- a/projects/make-a-vis/src/lib/toolbar/icons/info-icon/info-icon.component.ts
+++ b/projects/make-a-vis/src/lib/toolbar/icons/info-icon/info-icon.component.ts
@@ -1,6 +1,10 @@
 import { Component } from '@angular/core';
+import { Store } from '@ngrx/store';
 import { MatDialog, MatDialogConfig } from '@angular/material';
 import { InfoDialogComponent } from '../../info-dialog/info-dialog.component';
+import { OpenedInfoIcon } from '../../shared/store';
+import { SidenavState } from 'make-a-vis/lib/toolbar/shared/store';
+
 
 @Component({
   selector: 'mav-info-icon',
@@ -8,12 +12,12 @@ import { InfoDialogComponent } from '../../info-dialog/info-dialog.component';
   styleUrls: ['./info-icon.component.css']
 })
 export class InfoIconComponent {
-
-  constructor(private dialog: MatDialog) { }
+  constructor(private dialog: MatDialog, private store: Store<SidenavState>) { }
 
   openDialog() {
     const dialogConfig = new MatDialogConfig();
     dialogConfig.panelClass = 'mav-info-dialog-container';
     this.dialog.open(InfoDialogComponent, dialogConfig);
+    this.store.dispatch(new OpenedInfoIcon({opened: true}));
   }
 }

--- a/projects/make-a-vis/src/lib/toolbar/icons/info-icon/info-icon.component.ts
+++ b/projects/make-a-vis/src/lib/toolbar/icons/info-icon/info-icon.component.ts
@@ -3,7 +3,7 @@ import { Store } from '@ngrx/store';
 import { MatDialog, MatDialogConfig } from '@angular/material';
 import { InfoDialogComponent } from '../../info-dialog/info-dialog.component';
 import { OpenedInfoIcon } from '../../shared/store';
-import { SidenavState } from 'make-a-vis/lib/toolbar/shared/store';
+import { SidenavState } from '../../../toolbar/shared/store';
 
 
 @Component({

--- a/projects/make-a-vis/src/lib/toolbar/info-dialog/info-dialog.component.ts
+++ b/projects/make-a-vis/src/lib/toolbar/info-dialog/info-dialog.component.ts
@@ -1,7 +1,11 @@
 import { Component, OnInit } from '@angular/core';
 import { MatDialogRef } from '@angular/material';
+import { Store } from '@ngrx/store';
 
 import { buildInfo } from './build-info';
+import { ClosedInfoIcon } from '../shared/store';
+import { SidenavState } from 'make-a-vis/lib/toolbar/shared/store';
+
 
 
 @Component({
@@ -16,7 +20,7 @@ export class InfoDialogComponent implements OnInit {
   aboutusContent: any;
   contactusContent: any;
 
-  constructor(public dialogRef: MatDialogRef<InfoDialogComponent>) {
+  constructor(public dialogRef: MatDialogRef<InfoDialogComponent>, private store: Store<SidenavState>) {
     this.createItems();
     this.createAboutusContent();
     this.createContactusContent();
@@ -27,6 +31,7 @@ export class InfoDialogComponent implements OnInit {
 
   close() {
     this.dialogRef.close();
+    this.store.dispatch(new ClosedInfoIcon({opened: false}));
   }
 
   createItems() {

--- a/projects/make-a-vis/src/lib/toolbar/info-dialog/info-dialog.component.ts
+++ b/projects/make-a-vis/src/lib/toolbar/info-dialog/info-dialog.component.ts
@@ -4,7 +4,7 @@ import { Store } from '@ngrx/store';
 
 import { buildInfo } from './build-info';
 import { ClosedInfoIcon } from '../shared/store';
-import { SidenavState } from 'make-a-vis/lib/toolbar/shared/store';
+import { SidenavState } from '../../toolbar/shared/store';
 
 
 

--- a/projects/make-a-vis/src/lib/toolbar/shared/store/actions.ts
+++ b/projects/make-a-vis/src/lib/toolbar/shared/store/actions.ts
@@ -41,8 +41,12 @@ export enum SidenavActionTypes {
   UnsetGraphicVariable = '[UI] Unset Graphic Variable',
 
   CopyToClipboardSuccess = '[UI] Successfully Copied To Clipboard',
-  CopyToClipboardError = '[UI] Copy To Clipboard Failed'
+  CopyToClipboardError = '[UI] Copy To Clipboard Failed',
+
+  OpenInfoIcon = '[UI] Info Icon Opened',
+  CloseInfoIcon = '[UI] Info Icon Closed'
 }
+
 
 export class SaveProjectStarted implements Action {
   readonly type = SidenavActionTypes.SaveProjectStarted;
@@ -142,7 +146,7 @@ export class ToggleLogging implements Action {
 
 export class SetActiveVisualization implements Action {
   readonly type = SidenavActionTypes.SetActiveVisualization;
-  constructor(public payload: number) { }
+  constructor(public payload: payloadTypes.VisualizationId) { }
 }
 
 export class AddNewVisualization implements Action {
@@ -152,7 +156,7 @@ export class AddNewVisualization implements Action {
 
 export class RemoveVisualization implements Action {
   readonly type = SidenavActionTypes.RemoveVisualization;
-  constructor(public payload: number) { }
+  constructor(public payload: payloadTypes.VisualizationId) { }
 }
 
 export class SetRecordStream implements Action {
@@ -199,6 +203,16 @@ export class CopyToClipboardError implements Action {
   constructor(public payload: payloadTypes.CopyToClipboardErrorPayload) {}
 }
 
+export class OpenedInfoIcon implements Action {
+  readonly type = SidenavActionTypes.OpenInfoIcon;
+  constructor(public payload: payloadTypes.InfoIcon) {}
+}
+
+export class ClosedInfoIcon implements Action {
+  readonly type = SidenavActionTypes.CloseInfoIcon;
+  constructor(public payload: payloadTypes.InfoIcon) {}
+}
+
 export type SidenavActionsUnion = SaveProjectStarted | SaveProjectFileCreated | SaveProjectCompleted |
   LoadProjectStarted | LoadProjectCompleted | LoadProjectError |
   ExportSnapshotStarted | ExportSnapshotCompleted | ExportSnapshotError |
@@ -206,4 +220,4 @@ export type SidenavActionsUnion = SaveProjectStarted | SaveProjectFileCreated | 
   CreateShareUrlStarted | CreateShareUrlCompleted | CreateShareUrlError |
   ToggleLogging | SetActiveVisualization | AddNewVisualization | RemoveVisualization | SetRecordStream | UnsetRecordStream |
   SetGraphicSymbolRecordSet | SetActiveDataVariable | SetGraphicVariable | UnsetGraphicVariable |
-  CopyToClipboardSuccess | CopyToClipboardError;
+  CopyToClipboardSuccess | CopyToClipboardError | OpenedInfoIcon | ClosedInfoIcon;

--- a/projects/make-a-vis/src/lib/toolbar/shared/store/payload-types.ts
+++ b/projects/make-a-vis/src/lib/toolbar/shared/store/payload-types.ts
@@ -7,6 +7,10 @@ export interface LoadProjectStartedPayload {
   fileExtension: 'isi' | 'nsf' | 'csv' | 'json' | 'yml';
 }
 
+export interface VisualizationId {
+  visualizationId: number;
+}
+
 export interface LoadProjectCompletedPayload {
   loadingProject: boolean;
   fileName: string;
@@ -75,6 +79,10 @@ export interface SetGraphicSymbolRecordSetPayload {
 
 export interface CopyToClipboardSuccessPayload {
   content: String;
+}
+
+export interface InfoIcon {
+  opened: boolean;
 }
 
 export interface CopyToClipboardErrorPayload {

--- a/projects/make-a-vis/src/lib/toolbar/shared/store/reducer.ts
+++ b/projects/make-a-vis/src/lib/toolbar/shared/store/reducer.ts
@@ -94,7 +94,7 @@ export function sidenavStateReducer (
       case SidenavActionTypes.RemoveVisualization:
         if (state.project) {
           newState.project.visualizations = state.project.visualizations.slice();
-          newState.project.visualizations.splice(action.payload, 1);
+          newState.project.visualizations.splice(action.payload.visualizationId, 1);
         }
         return newState;
 

--- a/projects/make-a-vis/src/lib/toolbar/shared/store/state.ts
+++ b/projects/make-a-vis/src/lib/toolbar/shared/store/state.ts
@@ -1,5 +1,6 @@
 // refer https://angular.io/guide/styleguide#style-03-06 for import line spacing
 import { Project } from '@dvl-fw/core';
+import { VisualizationId } from './payload-types';
 
 export interface SidenavState {
   savingProject: boolean;
@@ -25,7 +26,9 @@ export interface SidenavState {
   errorMessage: string;
 
   project: Project;
-  activeVisualization: number;
+  activeVisualization: VisualizationId;
+
+  opened: boolean;
 }
 
 
@@ -53,5 +56,7 @@ export const INITIAL_SIDENAV_STATE: SidenavState = {
   errorMessage: '',
 
   project: null,
-  activeVisualization: -1
+  activeVisualization: { visualizationId : -1 },
+
+  opened: false
 };

--- a/projects/make-a-vis/src/lib/visualization-view/main/main.component.ts
+++ b/projects/make-a-vis/src/lib/visualization-view/main/main.component.ts
@@ -59,7 +59,7 @@ export class MainComponent {
     if (index !== this.selectedVis || force) {
       this.selectedVis = index;
       this.exportService.visualizationElement = this.visGroup;
-      this.store.dispatch(new SetActiveVisualization(index));
+      this.store.dispatch(new SetActiveVisualization({visualizationId: index}));
     }
     this.emitToggleAddVisEvent();
   }
@@ -72,7 +72,7 @@ export class MainComponent {
   removeVisualization(index: number): void {
     const lastIndex = this.visualizations.length - 1;
     this.visualizations.splice(index, 1);
-    this.store.dispatch(new RemoveVisualization(index));
+    this.store.dispatch(new RemoveVisualization({visualizationId: index}));
     this.setSelectedVis(index === lastIndex ? index - 1 : index, true);
   }
 


### PR DESCRIPTION
1. Removed the large schema and replaced it with payload object. Before writing to project file payload is converted to individual properties (except the project property, it is not being logged because of huge size.)
2. Instead of whitelisting the events now we are blacklisting the events which should not be loggged.
3. New event for info icon
4. Logging for GraphiVariableType, collapsable table (data view) etc.