### PR TITLE
added umdModuleIds to ng-package.json and ng-package.prod.json for the libraries

### DIFF
--- a/projects/dvl-fw/ng-package.json
+++ b/projects/dvl-fw/ng-package.json
@@ -3,6 +3,25 @@
   "dest": "../../dist/dvl-fw",
   "deleteDestPath": false,
   "lib": {
-    "entryFile": "src/public_api.ts"
+    "entryFile": "src/public_api.ts",
+    "umdModuleIds": {
+      "@ngx-dino/core": "@ngx-dino/core",
+      "@ngx-dino/geomap": "@ngx-dino/geomap",
+      "@ngx-dino/network": "@ngx-dino/network",
+      "@ngx-dino/legend": "@ngx-dino/legend",
+      "@ngx-dino/scatterplot": "@ngx-dino/scatterplot",
+      "@ngx-dino/science-map": "@ngx-dino/science-map",
+      "@ngx-dino/temporal-bargraph": "@ngx-dino/temporal-bargraph",
+      "d3-scale": "d3-scale",
+      "graphology": "graphology",
+      "graphology-layout-forceatlas2": "graphology-layout-forceatlas2",
+      "js-yaml": "js-yaml",
+      "lodash": "lodash",
+      "pako": "pako",
+      "papaparse": "papaparse",
+      "nano-sql": "nano-sql",
+      "typescript-logging": "typescript-logging",
+      "zipcodes": "zipcodes"
+    }
   }
 }

--- a/projects/dvl-fw/ng-package.prod.json
+++ b/projects/dvl-fw/ng-package.prod.json
@@ -2,6 +2,25 @@
   "$schema": "../../node_modules/ng-packagr/ng-package.schema.json",
   "dest": "../../dist/dvl-fw",
   "lib": {
-    "entryFile": "src/public_api.ts"
+    "entryFile": "src/public_api.ts",
+    "umdModuleIds": {
+      "@ngx-dino/core": "@ngx-dino/core",
+      "@ngx-dino/geomap": "@ngx-dino/geomap",
+      "@ngx-dino/network": "@ngx-dino/network",
+      "@ngx-dino/legend": "@ngx-dino/legend",
+      "@ngx-dino/scatterplot": "@ngx-dino/scatterplot",
+      "@ngx-dino/science-map": "@ngx-dino/science-map",
+      "@ngx-dino/temporal-bargraph": "@ngx-dino/temporal-bargraph",
+      "d3-scale": "d3-scale",
+      "graphology": "graphology",
+      "graphology-layout-forceatlas2": "graphology-layout-forceatlas2",
+      "js-yaml": "js-yaml",
+      "lodash": "lodash",
+      "pako": "pako",
+      "papaparse": "papaparse",
+      "nano-sql": "nano-sql",
+      "typescript-logging": "typescript-logging",
+      "zipcodes": "zipcodes"
+    }
   }
 }

--- a/projects/make-a-vis/ng-package.json
+++ b/projects/make-a-vis/ng-package.json
@@ -3,6 +3,22 @@
   "dest": "../../dist/make-a-vis",
   "deleteDestPath": false,
   "lib": {
-    "entryFile": "src/public_api.ts"
+    "entryFile": "src/public_api.ts",
+    "umdModuleIds": {
+      "@dvl-fw/core": "@dvl-fw/core",
+      "@ngrx/effects": "@ngrx/effects",
+      "@ngrx/store": "@ngrx/store",
+      "@ngx-dino/core": "@ngx-dino/core",
+      "blob-stream-browserify": "blob-stream-browserify",
+      "file-saver": "file-saver",
+      "lodash": "lodash",
+      "ngx-clipboard": "ngx-clipboard",
+      "ngx-markdown": "ngx-markdown",
+      "papaparse": "papaparse",
+      "pdfkit-browserify": "pdfkit-browserify",
+      "save-svg-as-png": "save-svg-as-png",
+      "svg-to-pdfkit": "svg-to-pdfkit",
+      "typescript-logging": "typescript-logging"
+    }
   }
 }

--- a/projects/make-a-vis/ng-package.prod.json
+++ b/projects/make-a-vis/ng-package.prod.json
@@ -2,6 +2,22 @@
   "$schema": "../../node_modules/ng-packagr/ng-package.schema.json",
   "dest": "../../dist/make-a-vis",
   "lib": {
-    "entryFile": "src/public_api.ts"
+    "entryFile": "src/public_api.ts",
+    "umdModuleIds": {
+      "@dvl-fw/core": "@dvl-fw/core",
+      "@ngrx/effects": "@ngrx/effects",
+      "@ngrx/store": "@ngrx/store",
+      "@ngx-dino/core": "@ngx-dino/core",
+      "blob-stream-browserify": "blob-stream-browserify",
+      "file-saver": "file-saver",
+      "lodash": "lodash",
+      "ngx-clipboard": "ngx-clipboard",
+      "ngx-markdown": "ngx-markdown",
+      "papaparse": "papaparse",
+      "pdfkit-browserify": "pdfkit-browserify",
+      "save-svg-as-png": "save-svg-as-png",
+      "svg-to-pdfkit": "svg-to-pdfkit",
+      "typescript-logging": "typescript-logging"
+    }
   }
 }


### PR DESCRIPTION
This made the warnings like the following disappear - 

`No name was provided for external module 'typescript-logging' in output.globals – guessing 'typescriptLogging'`